### PR TITLE
Upgrade tfjs-core and tfjs-converter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "watchify": "^3.10.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-converter": "0.1.0",
-    "@tensorflow/tfjs-core": "0.6.0",
+    "@tensorflow/tfjs-converter": "0.2.1",
+    "@tensorflow/tfjs-core": "0.9.0",
     "babel-polyfill": "^6.26.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,16 +45,16 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.1.0.tgz#8c305d34b5290122f2af368c33dc4fa2f688d9a2"
+"@tensorflow/tfjs-converter@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.2.1.tgz#7aa44e84f478cf6e3823aecd878bb1ff466e4078"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.0"
 
-"@tensorflow/tfjs-core@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.6.0.tgz#e33d9889472b0599291ecdb7fa83579586b21e66"
+"@tensorflow/tfjs-core@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.9.0.tgz#7e4b37e0c444c95abc8579d0a22b4f7d59c4248b"
   dependencies:
     seedrandom "~2.4.3"
 


### PR DESCRIPTION
Fixes #14 

By upgrading tfjs-converter and tfjs-core, the upstream fixes will be fallen down to the custom models.