### PR TITLE
Update Dockerfile to make retraining easier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ They are SavedModel files in a web-friendly format converted by the
 You can build your own game using your own custom image recognition model by replacing
 the corresponding files under the `dist/model/` directory with the newly generated ones.
 
-You also need to update `src/js/scavenger_classes.ts` in order to update the
-label outputs from the custom model with human-readable strings.
+The training script also generates `scavenger_classes.ts` for your custom model.
+Replace `src/js/scavenger_classes.ts` with it and build the app to run the game
+based on your custom model.
+
 Update the game logic in `src/js/game.ts` if needed.
 
 ### Using GPU

--- a/README.md
+++ b/README.md
@@ -74,9 +74,14 @@ They are SavedModel files in a web-friendly format converted by the
 You can build your own game using your own custom image recognition model by replacing
 the corresponding files under the `dist/model/` directory with the newly generated ones.
 
-The training script also generates `scavenger_classes.ts` for your custom model.
-Replace `src/js/scavenger_classes.ts` with it and build the app to run the game
-based on your custom model.
+The training script will also generate a file called `scavenger_classes.ts`
+which works in conjunction with your generated custom model.
+You need to replace the file at `src/js/scavenger_classes.ts` with this newly
+generated `scavenger_classes.ts` file so that the labels of your model match
+with the trained data.
+After replacing the file you can run the build script normally to test your
+model in a browser. See the README file for information on running a preview
+server.
 
 Update the game logic in `src/js/game.ts` if needed.
 

--- a/training/Dockerfile
+++ b/training/Dockerfile
@@ -11,9 +11,7 @@ RUN apt-get update && \
 
 RUN pip3 install -U pip
 
-RUN pip3 --no-cache-dir install \
-        tensorflow \
-        tensorflowjs
+RUN pip3 --no-cache-dir install tensorflowjs
 
 WORKDIR /
 
@@ -21,10 +19,19 @@ RUN git clone --depth 1 https://github.com/tensorflow/tensorflow.git --branch r1
 
 CMD python3 /tensorflow/tensorflow/examples/image_retraining/retrain.py \
         --image_dir /data/images \
-        --how_many_training_steps=10000 \
+        --how_many_training_steps=4000 \
+        --eval_step_interval=100 \
         --architecture mobilenet_0.25_224 \
+        --output_graph /data/graph.pb \
+        --summaries_dir /data/summaries \
         --output_labels /data/output_labels.txt \
+        --bottleneck_dir /data/bottleneck/ \
+        --intermediate_store_frequency 1000 \
+        --intermediate_output_graphs_dir /data/intermediate \
         --saved_model_dir /data/saved_model && \
+    echo 'export const SCAVENGER_CLASSES: {[key: number]: string} = {' > /data/scavenger_classes.ts && \
+    awk '{print NR-1  ": '\''" $0 "'\'',"}' /data/output_labels.txt >> /data/scavenger_classes.ts && \
+    echo '}' >> /data/scavenger_classes.ts && \
     python3 -m tensorflowjs.converters.converter \
         --input_format=tf_saved_model \
         --output_node_names='final_result' \

--- a/training/Dockerfile.gpu
+++ b/training/Dockerfile.gpu
@@ -11,20 +11,28 @@ RUN apt-get update && \
 
 RUN pip3 install -U pip
 
-RUN pip3 --no-cache-dir install \
-        tensorflow-gpu \
-        tensorflowjs
-
 WORKDIR /
 
 RUN git clone --depth 1 https://github.com/tensorflow/tensorflow.git --branch r1.7
 
+# Installing tensorflowjs package after training since it may overwrite the GPU version of TensorFlow.
+
 CMD python3 /tensorflow/tensorflow/examples/image_retraining/retrain.py \
         --image_dir /data/images \
-        --how_many_training_steps=10000 \
+        --how_many_training_steps=4000 \
+        --eval_step_interval=100 \
         --architecture mobilenet_0.25_224 \
+        --output_graph /data/graph.pb \
+        --summaries_dir /data/summaries \
         --output_labels /data/output_labels.txt \
+        --bottleneck_dir /data/bottleneck/ \
+        --intermediate_store_frequency 1000 \
+        --intermediate_output_graphs_dir /data/intermediate \
         --saved_model_dir /data/saved_model && \
+    echo 'export const SCAVENGER_CLASSES: {[key: number]: string} = {' > /data/scavenger_classes.ts && \
+    awk '{print NR-1  ": '\''" $0 "'\'',"}' /data/output_labels.txt >> /data/scavenger_classes.ts && \
+    echo '}' >> /data/scavenger_classes.ts && \
+    pip3 --no-cache-dir install tensorflowjs && \
     python3 -m tensorflowjs.converters.converter \
         --input_format=tf_saved_model \
         --output_node_names='final_result' \

--- a/training/Dockerfile.gpu
+++ b/training/Dockerfile.gpu
@@ -15,8 +15,6 @@ WORKDIR /
 
 RUN git clone --depth 1 https://github.com/tensorflow/tensorflow.git --branch r1.7
 
-# Installing tensorflowjs package after training since it may overwrite the GPU version of TensorFlow.
-
 CMD python3 /tensorflow/tensorflow/examples/image_retraining/retrain.py \
         --image_dir /data/images \
         --how_many_training_steps=4000 \
@@ -32,6 +30,7 @@ CMD python3 /tensorflow/tensorflow/examples/image_retraining/retrain.py \
     echo 'export const SCAVENGER_CLASSES: {[key: number]: string} = {' > /data/scavenger_classes.ts && \
     awk '{print NR-1  ": '\''" $0 "'\'',"}' /data/output_labels.txt >> /data/scavenger_classes.ts && \
     echo '}' >> /data/scavenger_classes.ts && \
+    # Installing tensorflowjs package after training since it may overwrite the GPU version of TensorFlow.
     pip3 --no-cache-dir install tensorflowjs && \
     python3 -m tensorflowjs.converters.converter \
         --input_format=tf_saved_model \


### PR DESCRIPTION
- Generate `scavenger_classes.ts` for the retrained model. (solves #32 )
- Update README to instruct replacing `scavenger_classes.ts`.
- Solve the issue that TensorFlow GPU is overwritten by other
  submodules.
- Move bottolneck dir under /data to make rerun easy.