### PR TITLE
Update ui.ts DOM text reinterpreted as HTML

### DIFF
--- a/src/js/ui.ts
+++ b/src/js/ui.ts
@@ -559,7 +559,7 @@ export class Ui {
   setSleuthSpeakerText(msg: string, msgMarkup = false) {
 
     if (msgMarkup) {
-      this.sleuthSpeakingEl.innerHTML = msg;
+      this.sleuthSpeakingEl.innerText = msg;
     } else {
       this.sleuthSpeakingEl.textContent = msg;
     }

--- a/src/js/ui.ts
+++ b/src/js/ui.ts
@@ -559,7 +559,7 @@ export class Ui {
   setSleuthSpeakerText(msg: string, msgMarkup = false) {
 
     if (msgMarkup) {
-      this.sleuthSpeakingEl.innerText = msg;
+      this.sleuthSpeakingEl.textContent = msg;
     } else {
       this.sleuthSpeakingEl.textContent = msg;
     }


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML. Always be cautious when dealing with user input or dynamic content to prevent security risks.